### PR TITLE
fix(ci): update ci cimg, noissue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
-aliases:
-    - &cache-key dependency-cache-{{ checksum "package.json" }}
-    - &cache-key-fallback dependency-cache-
+orbs:
+    node: circleci/node@4.1
 
 executors:
     default:
@@ -11,52 +10,25 @@ executors:
             - image: cimg/node:lts
 
 jobs:
-    checkout_code:
-        executor: default
-        steps:
-            - checkout
-            - persist_to_workspace:
-                  root: ~/repo
-                  paths:
-                      - .
     test:
         executor: default
         steps:
-            - attach_workspace:
-                  at: ~/repo
-            - restore_cache:
-                  keys:
-                      - *cache-key
-                      - *cache-key-fallback
-            - run: npm install
-            - run: npm rebuild
-            - save_cache:
-                  key: *cache-key
-                  paths:
-                      - ./node_modules
+            - checkout
+            - node/install-packages
             - run: npm run lint
             - run: npm test
-            - persist_to_workspace:
-                  root: ~/repo
-                  paths:
-                      - node_modules
 
     release:
         executor: default
         steps:
-            - attach_workspace:
-                  at: ~/repo
             - checkout
+            - node/install-packages
             - run: npm run semantic-release
 
 workflows:
-    version: 2
     build:
         jobs:
-            - checkout_code
-            - test:
-                  requires:
-                      - checkout_code
+            - test
             - release:
                   context: org-global
                   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,45 +1,52 @@
-aliases:
-    - &dir ~/repo
-    - &defaults
-      working_directory: *dir
-      docker:
-          - image: circleci/node:lts
-    - &cache_key
-      key: dependency-cache-{{ checksum "package.json" }}
-    - &attach_workspace
-      attach_workspace:
-          at: *dir
+version: 2.1
 
-version: 2
+aliases:
+    - &cache-key dependency-cache-{{ checksum "package.json" }}
+    - &cache-key-fallback dependency-cache-
+
+executors:
+    default:
+        working_directory: ~/repo
+        docker:
+            - image: cimg/node:lts
+
 jobs:
     checkout_code:
-        <<: *defaults
+        executor: default
         steps:
             - checkout
-            - restore_cache:
-                  <<: *cache_key
-            - run: npm install
-            - save_cache:
-                  <<: *cache_key
-                  paths:
-                      - ./node_modules
             - persist_to_workspace:
-                  root: *dir
+                  root: ~/repo
                   paths:
                       - .
-
     test:
-        <<: *defaults
+        executor: default
         steps:
-            - *attach_workspace
+            - attach_workspace:
+                  at: ~/repo
+            - restore_cache:
+                  keys:
+                      - *cache-key
+                      - *cache-key-fallback
+            - run: npm install
+            - run: npm rebuild
+            - save_cache:
+                  key: *cache-key
+                  paths:
+                      - ./node_modules
             - run: npm run lint
             - run: npm test
+            - persist_to_workspace:
+                  root: ~/repo
+                  paths:
+                      - node_modules
 
     release:
-        <<: *defaults
+        executor: default
         steps:
-            - *attach_workspace
-            # - checkout # Commenting this line out as I don't think it is needed, please uncomment if the release fails
+            - attach_workspace:
+                  at: ~/repo
+            - checkout
             - run: npm run semantic-release
 
 workflows:
@@ -54,7 +61,3 @@ workflows:
                   context: org-global
                   requires:
                       - test
-                  filters:
-                      branches:
-                          only:
-                              - main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "eslint-plugin-sequel",
-	"version": "1.9.2",
+	"version": "1.9.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.9.2",
+			"version": "1.9.5",
 			"license": "ISC",
 			"dependencies": {
 				"requireindex": "^1.2.0"
@@ -24,7 +24,7 @@
 				"nyc": "^15.1.0",
 				"prettier": "^2.2.1",
 				"pretty-quick": "^3.1.0",
-				"semantic-release": "^17.4.2"
+				"semantic-release": "^17.4.7"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -4480,26 +4480,27 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-7.20.5.tgz",
-			"integrity": "sha512-vRyu1V79n5BzKn4vkanag1xEjEMLIZ48Ry1V7IyAvHQHi8syOEiYWvUMxNpeDk+e8JKAKCNG3lIYJDm3pM8VMQ==",
+			"version": "7.22.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-7.22.0.tgz",
+			"integrity": "sha512-HJnjTCrGGnacPMCSnrxuHGf2H4VdrY7hwTAK1RwByg0K96KIuTR4QNioFW+bnc/pW0uwpk9lLsDf4BeEQhTv2Q==",
 			"bundleDependencies": [
 				"@npmcli/arborist",
 				"@npmcli/ci-detect",
 				"@npmcli/config",
+				"@npmcli/map-workspaces",
 				"@npmcli/package-json",
 				"@npmcli/run-script",
 				"abbrev",
 				"ansicolors",
 				"ansistyles",
 				"archy",
-				"byte-size",
 				"cacache",
 				"chalk",
 				"chownr",
 				"cli-columns",
 				"cli-table3",
 				"columnify",
+				"fastest-levenshtein",
 				"glob",
 				"graceful-fs",
 				"hosted-git-info",
@@ -4507,7 +4508,6 @@
 				"init-package-json",
 				"is-cidr",
 				"json-parse-even-better-errors",
-				"leven",
 				"libnpmaccess",
 				"libnpmdiff",
 				"libnpmexec",
@@ -4555,74 +4555,74 @@
 			],
 			"dev": true,
 			"dependencies": {
-				"@npmcli/arborist": "^2.8.0",
-				"@npmcli/ci-detect": "^1.2.0",
-				"@npmcli/config": "^2.2.0",
-				"@npmcli/package-json": "^1.0.1",
-				"@npmcli/run-script": "^1.8.5",
-				"abbrev": "~1.1.1",
-				"ansicolors": "~0.3.2",
-				"ansistyles": "~0.1.3",
-				"archy": "~1.0.0",
-				"byte-size": "^7.0.1",
-				"cacache": "^15.2.0",
-				"chalk": "^4.1.2",
-				"chownr": "^2.0.0",
-				"cli-columns": "^3.1.2",
-				"cli-table3": "^0.6.0",
-				"columnify": "~1.5.4",
-				"glob": "^7.1.7",
-				"graceful-fs": "^4.2.8",
-				"hosted-git-info": "^4.0.2",
-				"ini": "^2.0.0",
-				"init-package-json": "^2.0.3",
-				"is-cidr": "^4.0.2",
-				"json-parse-even-better-errors": "^2.3.1",
-				"leven": "^3.1.0",
-				"libnpmaccess": "^4.0.2",
-				"libnpmdiff": "^2.0.4",
-				"libnpmexec": "^2.0.1",
-				"libnpmfund": "^1.1.0",
-				"libnpmhook": "^6.0.2",
-				"libnpmorg": "^2.0.2",
-				"libnpmpack": "^2.0.1",
-				"libnpmpublish": "^4.0.1",
-				"libnpmsearch": "^3.1.1",
-				"libnpmteam": "^2.0.3",
-				"libnpmversion": "^1.2.1",
-				"make-fetch-happen": "^9.0.4",
-				"minipass": "^3.1.3",
-				"minipass-pipeline": "^1.2.4",
-				"mkdirp": "^1.0.4",
-				"mkdirp-infer-owner": "^2.0.0",
-				"ms": "^2.1.2",
-				"node-gyp": "^7.1.2",
-				"nopt": "^5.0.0",
-				"npm-audit-report": "^2.1.5",
-				"npm-package-arg": "^8.1.5",
-				"npm-pick-manifest": "^6.1.1",
-				"npm-profile": "^5.0.3",
-				"npm-registry-fetch": "^11.0.0",
-				"npm-user-validate": "^1.0.1",
-				"npmlog": "^5.0.0",
-				"opener": "^1.5.2",
-				"pacote": "^11.3.5",
-				"parse-conflict-json": "^1.1.1",
-				"qrcode-terminal": "^0.12.0",
-				"read": "~1.0.7",
-				"read-package-json": "^3.0.1",
-				"read-package-json-fast": "^2.0.3",
-				"readdir-scoped-modules": "^1.1.0",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"ssri": "^8.0.1",
-				"tar": "^6.1.6",
-				"text-table": "~0.2.0",
-				"tiny-relative-date": "^1.3.0",
-				"treeverse": "^1.0.4",
-				"validate-npm-package-name": "~3.0.0",
-				"which": "^2.0.2",
-				"write-file-atomic": "^3.0.3"
+				"@npmcli/arborist": "*",
+				"@npmcli/ci-detect": "*",
+				"@npmcli/config": "*",
+				"@npmcli/map-workspaces": "*",
+				"@npmcli/package-json": "*",
+				"@npmcli/run-script": "*",
+				"abbrev": "*",
+				"ansicolors": "*",
+				"ansistyles": "*",
+				"archy": "*",
+				"cacache": "*",
+				"chalk": "*",
+				"chownr": "*",
+				"cli-columns": "*",
+				"cli-table3": "*",
+				"columnify": "*",
+				"fastest-levenshtein": "*",
+				"glob": "*",
+				"graceful-fs": "*",
+				"hosted-git-info": "*",
+				"ini": "*",
+				"init-package-json": "*",
+				"is-cidr": "*",
+				"json-parse-even-better-errors": "*",
+				"libnpmaccess": "*",
+				"libnpmdiff": "*",
+				"libnpmexec": "*",
+				"libnpmfund": "*",
+				"libnpmhook": "*",
+				"libnpmorg": "*",
+				"libnpmpack": "*",
+				"libnpmpublish": "*",
+				"libnpmsearch": "*",
+				"libnpmteam": "*",
+				"libnpmversion": "*",
+				"make-fetch-happen": "*",
+				"minipass": "*",
+				"minipass-pipeline": "*",
+				"mkdirp": "*",
+				"mkdirp-infer-owner": "*",
+				"ms": "*",
+				"node-gyp": "*",
+				"nopt": "*",
+				"npm-audit-report": "*",
+				"npm-package-arg": "*",
+				"npm-pick-manifest": "*",
+				"npm-profile": "*",
+				"npm-registry-fetch": "*",
+				"npm-user-validate": "*",
+				"npmlog": "*",
+				"opener": "*",
+				"pacote": "*",
+				"parse-conflict-json": "*",
+				"qrcode-terminal": "*",
+				"read": "*",
+				"read-package-json": "*",
+				"read-package-json-fast": "*",
+				"readdir-scoped-modules": "*",
+				"rimraf": "*",
+				"semver": "*",
+				"ssri": "*",
+				"tar": "*",
+				"text-table": "*",
+				"tiny-relative-date": "*",
+				"treeverse": "*",
+				"validate-npm-package-name": "*",
+				"which": "*",
+				"write-file-atomic": "*"
 			},
 			"bin": {
 				"npm": "bin/npm-cli.js",
@@ -4644,8 +4644,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm/node_modules/@gar/promisify": {
+			"version": "1.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "2.8.0",
+			"version": "2.8.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -4679,7 +4685,6 @@
 				"rimraf": "^3.0.2",
 				"semver": "^7.3.5",
 				"ssri": "^8.0.1",
-				"tar": "^6.1.0",
 				"treeverse": "^1.0.4",
 				"walk-up-path": "^1.0.0"
 			},
@@ -4697,7 +4702,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -4722,6 +4727,16 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/fs": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promisify": "^1.0.1",
+				"semver": "^7.3.5"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
@@ -4757,7 +4772,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -4826,14 +4841,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "1.8.5",
+			"version": "1.8.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/node-gyp": "^1.0.2",
 				"@npmcli/promise-spawn": "^1.3.2",
-				"infer-owner": "^1.0.4",
 				"node-gyp": "^7.1.0",
 				"read-package-json-fast": "^2.0.1"
 			}
@@ -4957,13 +4971,16 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/are-we-there-yet": {
-			"version": "1.1.5",
+			"version": "1.1.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/npm/node_modules/asap": {
@@ -5068,21 +5085,13 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/npm/node_modules/byte-size": {
-			"version": "7.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "15.2.0",
+			"version": "15.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
+				"@npmcli/fs": "^1.0.0",
 				"@npmcli/move-file": "^1.0.1",
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
@@ -5507,6 +5516,12 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
+		"node_modules/npm/node_modules/fastest-levenshtein": {
+			"version": "1.0.12",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
 		"node_modules/npm/node_modules/forever-agent": {
 			"version": "0.6.1",
 			"dev": true,
@@ -5785,7 +5800,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "2.0.3",
+			"version": "2.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5794,7 +5809,7 @@
 				"npm-package-arg": "^8.1.2",
 				"promzard": "^0.3.0",
 				"read": "~1.0.1",
-				"read-package-json": "^3.0.1",
+				"read-package-json": "^4.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4",
 				"validate-npm-package-name": "^3.0.0"
@@ -5831,7 +5846,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-core-module": {
-			"version": "2.5.0",
+			"version": "2.6.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -5866,7 +5881,6 @@
 		"node_modules/npm/node_modules/isarray": {
 			"version": "1.0.0",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/isexe": {
@@ -5954,15 +5968,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/leven": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
 			"version": "4.0.3",
@@ -6136,7 +6141,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "9.0.4",
+			"version": "9.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6155,7 +6160,7 @@
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^0.6.2",
 				"promise-retry": "^2.0.1",
-				"socks-proxy-agent": "^5.0.0",
+				"socks-proxy-agent": "^6.0.0",
 				"ssri": "^8.0.0"
 			},
 			"engines": {
@@ -6220,7 +6225,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "1.3.4",
+			"version": "1.4.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -6442,13 +6447,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "3.0.2",
+			"version": "3.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -6575,15 +6580,28 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/npm/node_modules/npmlog": {
-			"version": "5.0.0",
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"are-we-there-yet": "^1.1.5",
+				"are-we-there-yet": "^2.0.0",
 				"console-control-strings": "^1.1.0",
 				"gauge": "^3.0.0",
 				"set-blocking": "^2.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/npm/node_modules/number-is-nan": {
@@ -6702,7 +6720,6 @@
 		"node_modules/npm/node_modules/path-parse": {
 			"version": "1.0.7",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/performance-now": {
@@ -6720,7 +6737,6 @@
 		"node_modules/npm/node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
@@ -6820,7 +6836,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/read-package-json": {
-			"version": "3.0.1",
+			"version": "4.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6848,18 +6864,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/readable-stream": {
-			"version": "2.3.7",
+			"version": "3.6.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/npm/node_modules/readdir-scoped-modules": {
@@ -6935,7 +6950,6 @@
 		"node_modules/npm/node_modules/resolve": {
 			"version": "1.20.0",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.2.0",
@@ -6970,8 +6984,22 @@
 			}
 		},
 		"node_modules/npm/node_modules/safe-buffer": {
-			"version": "5.1.2",
+			"version": "5.2.1",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -7009,7 +7037,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/smart-buffer": {
-			"version": "4.1.0",
+			"version": "4.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -7033,17 +7061,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks-proxy-agent": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "6",
-				"debug": "4",
-				"socks": "^2.3.3"
+				"agent-base": "^6.0.2",
+				"debug": "^4.3.1",
+				"socks": "^2.6.1"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/npm/node_modules/spdx-correct": {
@@ -7073,7 +7101,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/spdx-license-ids": {
-			"version": "3.0.9",
+			"version": "3.0.10",
 			"dev": true,
 			"inBundle": true,
 			"license": "CC0-1.0"
@@ -7111,12 +7139,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/string_decoder": {
-			"version": "1.1.1",
+			"version": "1.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/npm/node_modules/string-width": {
@@ -7184,7 +7212,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "6.1.6",
+			"version": "6.1.11",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8517,9 +8545,9 @@
 			"dev": true
 		},
 		"node_modules/semantic-release": {
-			"version": "17.4.4",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.4.tgz",
-			"integrity": "sha512-fQIA0lw2Sy/9+TcoM/BxyzKCSwdUd8EPRwGoOuBLgxKigPCY6kaKs8TOsgUVy6QrlTYwni2yzbMb5Q2107P9eA==",
+			"version": "17.4.7",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
+			"integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
 			"dev": true,
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^8.0.0",
@@ -8555,7 +8583,7 @@
 				"semantic-release": "bin/semantic-release.js"
 			},
 			"engines": {
-				"node": ">=10.18"
+				"node": ">=10.19"
 			}
 		},
 		"node_modules/semantic-release/node_modules/execa": {
@@ -13014,83 +13042,88 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-7.20.5.tgz",
-			"integrity": "sha512-vRyu1V79n5BzKn4vkanag1xEjEMLIZ48Ry1V7IyAvHQHi8syOEiYWvUMxNpeDk+e8JKAKCNG3lIYJDm3pM8VMQ==",
+			"version": "7.22.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-7.22.0.tgz",
+			"integrity": "sha512-HJnjTCrGGnacPMCSnrxuHGf2H4VdrY7hwTAK1RwByg0K96KIuTR4QNioFW+bnc/pW0uwpk9lLsDf4BeEQhTv2Q==",
 			"dev": true,
 			"requires": {
-				"@npmcli/arborist": "^2.8.0",
-				"@npmcli/ci-detect": "^1.2.0",
-				"@npmcli/config": "^2.2.0",
-				"@npmcli/package-json": "^1.0.1",
-				"@npmcli/run-script": "^1.8.5",
-				"abbrev": "~1.1.1",
-				"ansicolors": "~0.3.2",
-				"ansistyles": "~0.1.3",
-				"archy": "~1.0.0",
-				"byte-size": "^7.0.1",
-				"cacache": "^15.2.0",
-				"chalk": "^4.1.2",
-				"chownr": "^2.0.0",
-				"cli-columns": "^3.1.2",
-				"cli-table3": "^0.6.0",
-				"columnify": "~1.5.4",
-				"glob": "^7.1.7",
-				"graceful-fs": "^4.2.8",
-				"hosted-git-info": "^4.0.2",
-				"ini": "^2.0.0",
-				"init-package-json": "^2.0.3",
-				"is-cidr": "^4.0.2",
-				"json-parse-even-better-errors": "^2.3.1",
-				"leven": "^3.1.0",
-				"libnpmaccess": "^4.0.2",
-				"libnpmdiff": "^2.0.4",
-				"libnpmexec": "^2.0.1",
-				"libnpmfund": "^1.1.0",
-				"libnpmhook": "^6.0.2",
-				"libnpmorg": "^2.0.2",
-				"libnpmpack": "^2.0.1",
-				"libnpmpublish": "^4.0.1",
-				"libnpmsearch": "^3.1.1",
-				"libnpmteam": "^2.0.3",
-				"libnpmversion": "^1.2.1",
-				"make-fetch-happen": "^9.0.4",
-				"minipass": "^3.1.3",
-				"minipass-pipeline": "^1.2.4",
-				"mkdirp": "^1.0.4",
-				"mkdirp-infer-owner": "^2.0.0",
-				"ms": "^2.1.2",
-				"node-gyp": "^7.1.2",
-				"nopt": "^5.0.0",
-				"npm-audit-report": "^2.1.5",
-				"npm-package-arg": "^8.1.5",
-				"npm-pick-manifest": "^6.1.1",
-				"npm-profile": "^5.0.3",
-				"npm-registry-fetch": "^11.0.0",
-				"npm-user-validate": "^1.0.1",
-				"npmlog": "^5.0.0",
-				"opener": "^1.5.2",
-				"pacote": "^11.3.5",
-				"parse-conflict-json": "^1.1.1",
-				"qrcode-terminal": "^0.12.0",
-				"read": "~1.0.7",
-				"read-package-json": "^3.0.1",
-				"read-package-json-fast": "^2.0.3",
-				"readdir-scoped-modules": "^1.1.0",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"ssri": "^8.0.1",
-				"tar": "^6.1.6",
-				"text-table": "~0.2.0",
-				"tiny-relative-date": "^1.3.0",
-				"treeverse": "^1.0.4",
-				"validate-npm-package-name": "~3.0.0",
-				"which": "^2.0.2",
-				"write-file-atomic": "^3.0.3"
+				"@npmcli/arborist": "*",
+				"@npmcli/ci-detect": "*",
+				"@npmcli/config": "*",
+				"@npmcli/map-workspaces": "*",
+				"@npmcli/package-json": "*",
+				"@npmcli/run-script": "*",
+				"abbrev": "*",
+				"ansicolors": "*",
+				"ansistyles": "*",
+				"archy": "*",
+				"cacache": "*",
+				"chalk": "*",
+				"chownr": "*",
+				"cli-columns": "*",
+				"cli-table3": "*",
+				"columnify": "*",
+				"fastest-levenshtein": "*",
+				"glob": "*",
+				"graceful-fs": "*",
+				"hosted-git-info": "*",
+				"ini": "*",
+				"init-package-json": "*",
+				"is-cidr": "*",
+				"json-parse-even-better-errors": "*",
+				"libnpmaccess": "*",
+				"libnpmdiff": "*",
+				"libnpmexec": "*",
+				"libnpmfund": "*",
+				"libnpmhook": "*",
+				"libnpmorg": "*",
+				"libnpmpack": "*",
+				"libnpmpublish": "*",
+				"libnpmsearch": "*",
+				"libnpmteam": "*",
+				"libnpmversion": "*",
+				"make-fetch-happen": "*",
+				"minipass": "*",
+				"minipass-pipeline": "*",
+				"mkdirp": "*",
+				"mkdirp-infer-owner": "*",
+				"ms": "*",
+				"node-gyp": "*",
+				"nopt": "*",
+				"npm-audit-report": "*",
+				"npm-package-arg": "*",
+				"npm-pick-manifest": "*",
+				"npm-profile": "*",
+				"npm-registry-fetch": "*",
+				"npm-user-validate": "*",
+				"npmlog": "*",
+				"opener": "*",
+				"pacote": "*",
+				"parse-conflict-json": "*",
+				"qrcode-terminal": "*",
+				"read": "*",
+				"read-package-json": "*",
+				"read-package-json-fast": "*",
+				"readdir-scoped-modules": "*",
+				"rimraf": "*",
+				"semver": "*",
+				"ssri": "*",
+				"tar": "*",
+				"text-table": "*",
+				"tiny-relative-date": "*",
+				"treeverse": "*",
+				"validate-npm-package-name": "*",
+				"which": "*",
+				"write-file-atomic": "*"
 			},
 			"dependencies": {
+				"@gar/promisify": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true
+				},
 				"@npmcli/arborist": {
-					"version": "2.8.0",
+					"version": "2.8.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -13123,7 +13156,6 @@
 						"rimraf": "^3.0.2",
 						"semver": "^7.3.5",
 						"ssri": "^8.0.1",
-						"tar": "^6.1.0",
 						"treeverse": "^1.0.4",
 						"walk-up-path": "^1.0.0"
 					}
@@ -13134,7 +13166,7 @@
 					"dev": true
 				},
 				"@npmcli/config": {
-					"version": "2.2.0",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -13151,6 +13183,15 @@
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.3.0"
+					}
+				},
+				"@npmcli/fs": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@gar/promisify": "^1.0.1",
+						"semver": "^7.3.5"
 					}
 				},
 				"@npmcli/git": {
@@ -13178,7 +13219,7 @@
 					}
 				},
 				"@npmcli/map-workspaces": {
-					"version": "1.0.3",
+					"version": "1.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -13234,13 +13275,12 @@
 					}
 				},
 				"@npmcli/run-script": {
-					"version": "1.8.5",
+					"version": "1.8.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@npmcli/node-gyp": "^1.0.2",
 						"@npmcli/promise-spawn": "^1.3.2",
-						"infer-owner": "^1.0.4",
 						"node-gyp": "^7.1.0",
 						"read-package-json-fast": "^2.0.1"
 					}
@@ -13327,12 +13367,12 @@
 					"dev": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.5",
+					"version": "1.1.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"readable-stream": "^3.6.0"
 					}
 				},
 				"asap": {
@@ -13413,16 +13453,12 @@
 					"bundled": true,
 					"dev": true
 				},
-				"byte-size": {
-					"version": "7.0.1",
-					"bundled": true,
-					"dev": true
-				},
 				"cacache": {
-					"version": "15.2.0",
+					"version": "15.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"@npmcli/fs": "^1.0.0",
 						"@npmcli/move-file": "^1.0.1",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.0.0",
@@ -13720,6 +13756,11 @@
 					"bundled": true,
 					"dev": true
 				},
+				"fastest-levenshtein": {
+					"version": "1.0.12",
+					"bundled": true,
+					"dev": true
+				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
@@ -13919,7 +13960,7 @@
 					"dev": true
 				},
 				"init-package-json": {
-					"version": "2.0.3",
+					"version": "2.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -13927,7 +13968,7 @@
 						"npm-package-arg": "^8.1.2",
 						"promzard": "^0.3.0",
 						"read": "~1.0.1",
-						"read-package-json": "^3.0.1",
+						"read-package-json": "^4.0.0",
 						"semver": "^7.3.5",
 						"validate-npm-package-license": "^3.0.4",
 						"validate-npm-package-name": "^3.0.0"
@@ -13952,7 +13993,7 @@
 					}
 				},
 				"is-core-module": {
-					"version": "2.5.0",
+					"version": "2.6.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -13976,7 +14017,6 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
 					"dev": true
 				},
 				"isexe": {
@@ -14042,11 +14082,6 @@
 				},
 				"just-diff-apply": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"leven": {
-					"version": "3.1.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -14180,7 +14215,7 @@
 					}
 				},
 				"make-fetch-happen": {
-					"version": "9.0.4",
+					"version": "9.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -14198,7 +14233,7 @@
 						"minipass-pipeline": "^1.2.4",
 						"negotiator": "^0.6.2",
 						"promise-retry": "^2.0.1",
-						"socks-proxy-agent": "^5.0.0",
+						"socks-proxy-agent": "^6.0.0",
 						"ssri": "^8.0.0"
 					}
 				},
@@ -14240,7 +14275,7 @@
 					}
 				},
 				"minipass-fetch": {
-					"version": "1.3.4",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -14399,12 +14434,12 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
@@ -14497,14 +14532,25 @@
 					"dev": true
 				},
 				"npmlog": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"are-we-there-yet": "^1.1.5",
+						"are-we-there-yet": "^2.0.0",
 						"console-control-strings": "^1.1.0",
 						"gauge": "^3.0.0",
 						"set-blocking": "^2.0.0"
+					},
+					"dependencies": {
+						"are-we-there-yet": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						}
 					}
 				},
 				"number-is-nan": {
@@ -14586,7 +14632,6 @@
 				},
 				"path-parse": {
 					"version": "1.0.7",
-					"bundled": true,
 					"dev": true
 				},
 				"performance-now": {
@@ -14601,7 +14646,6 @@
 				},
 				"process-nextick-args": {
 					"version": "2.0.1",
-					"bundled": true,
 					"dev": true
 				},
 				"promise-all-reject-late": {
@@ -14670,7 +14714,7 @@
 					"dev": true
 				},
 				"read-package-json": {
-					"version": "3.0.1",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -14690,17 +14734,13 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.7",
+					"version": "3.6.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				},
 				"readdir-scoped-modules": {
@@ -14764,7 +14804,6 @@
 				},
 				"resolve": {
 					"version": "1.20.0",
-					"bundled": true,
 					"dev": true,
 					"requires": {
 						"is-core-module": "^2.2.0",
@@ -14785,7 +14824,7 @@
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.2",
+					"version": "5.2.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -14813,7 +14852,7 @@
 					"dev": true
 				},
 				"smart-buffer": {
-					"version": "4.1.0",
+					"version": "4.2.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -14827,13 +14866,13 @@
 					}
 				},
 				"socks-proxy-agent": {
-					"version": "5.0.0",
+					"version": "6.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"agent-base": "6",
-						"debug": "4",
-						"socks": "^2.3.3"
+						"agent-base": "^6.0.2",
+						"debug": "^4.3.1",
+						"socks": "^2.6.1"
 					}
 				},
 				"spdx-correct": {
@@ -14860,7 +14899,7 @@
 					}
 				},
 				"spdx-license-ids": {
-					"version": "3.0.9",
+					"version": "3.0.10",
 					"bundled": true,
 					"dev": true
 				},
@@ -14889,11 +14928,11 @@
 					}
 				},
 				"string_decoder": {
-					"version": "1.1.1",
+					"version": "1.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "~5.2.0"
 					}
 				},
 				"string-width": {
@@ -14942,7 +14981,7 @@
 					}
 				},
 				"tar": {
-					"version": "6.1.6",
+					"version": "6.1.11",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -15945,9 +15984,9 @@
 			"dev": true
 		},
 		"semantic-release": {
-			"version": "17.4.4",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.4.tgz",
-			"integrity": "sha512-fQIA0lw2Sy/9+TcoM/BxyzKCSwdUd8EPRwGoOuBLgxKigPCY6kaKs8TOsgUVy6QrlTYwni2yzbMb5Q2107P9eA==",
+			"version": "17.4.7",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
+			"integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
 			"dev": true,
 			"requires": {
 				"@semantic-release/commit-analyzer": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"nyc": "^15.1.0",
 		"prettier": "^2.2.1",
 		"pretty-quick": "^3.1.0",
-		"semantic-release": "^17.4.2"
+		"semantic-release": "^17.4.7"
 	},
 	"nyc": {
 		"check-coverage": true,


### PR DESCRIPTION
Updates the node base image in our circleci config, after we received the following email advice...

> Why migrate?
> - More deterministic: The newest images will be rebuilt only for security and critical-bugs, drastically reducing breaking changes from updates in legacy images.
> - Faster build times: Our newest images get faster as our community uses them due to improved caching. Migrating to the new image is good for your builds and for the builds of the larger Node.js community.
> - As of Dec 31, 2021, legacy images will no longer be supported on CircleCI. View more information on our image deprecation timeline here.


... they should have lead with the deprecation notice (the last point)
